### PR TITLE
Fix generating URLs for offers without sponsor

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -8,6 +8,9 @@ class Offer < ApplicationRecord
   validates :description, presence: true
 
   def to_param
-    "#{id}-#{sponsor.name}-#{title}".parameterize
+    [id, sponsor&.name, title]
+      .compact
+      .join('-')
+      .parameterize
   end
 end


### PR DESCRIPTION
There's still a possibility to create an offer without the sponsor. All one has to do is go to /admin/offers and there's no input for  choosing sponsor ID, because you're supposed to create offer via sponsor page.

So long story short, we have an offer without sponsor, 500 on server and PR to fix that.