### PR TITLE
Add MIT license file and readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Marcin Gajewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ bundle exec rake db:migrate
 ```
 
 [![coditsu](https://coditsu.io/assets/quality_bar.svg)](https://app.coditsu.io/krakow-ruby-users-group/repositories/krug-website/builds/commit_builds)
+
+## License
+
+KRUG-website is released under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Relates to #12 

License text if taken from https://opensource.org/licenses/mit-license.php 
(by copying it with github feature : )
I mentioned @gajewsky 
But can be org with link e.g. `Google LLC. http://angular.io/license` 

I read also that CONTRIBUTORS can be defined in separate file  